### PR TITLE
Make the config file overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Rather than reporting all MAC addresses seen ```mqtt-arp``` takes a list of MACs to watch for. I have this configured for my phone, resulting in a reasonable proxy for whether I am home or not. ```mqtt-arp``` will report as soon as the device is seen, and send rate-limited (at most once every 2 minutes) updates when it is seen again. If the device is not seen for at least 10 minutes the location will be reported as "unknown".
 
-There is basic configuration file support; by default ```mqtt-arp``` will read ```/etc/mqtt-arp.conf```. The following aspects can be configured at run time:
+There is basic configuration file support; by default ```mqtt-arp``` will read ```/etc/mqtt-arp.conf```. The location can be overridable, see below. 
+The following aspects can be configured at run time:
 
  * MQTT host (-h / --host / mqtt_host)
  * MQTT post (-p / --port / mqtt_port)
@@ -12,5 +13,6 @@ There is basic configuration file support; by default ```mqtt-arp``` will read `
  * Location to report when device is present (-l / --location / location)
  * Path to SSL certificate bundle (-c / --capath / capath)
  * MAC addresses to watch for  (-m / --mac / mac)
+ * Read config file at specific location (-f / --configfile / file path)
 
 This code is released as GPLv3+ and is available at [https://the.earth.li/gitweb/?p=mqtt-arp.git;a=summary](https://the.earth.li/gitweb/?p=mqtt-arp.git;a=summary) or on GitHub for easy whatever at [https://github.com/u1f35c/mqtt-arp](https://github.com/u1f35c/mqtt-arp)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Rather than reporting all MAC addresses seen ```mqtt-arp``` takes a list of MACs to watch for. I have this configured for my phone, resulting in a reasonable proxy for whether I am home or not. ```mqtt-arp``` will report as soon as the device is seen, and send rate-limited (at most once every 2 minutes) updates when it is seen again. If the device is not seen for at least 10 minutes the location will be reported as "unknown".
 
-There is basic configuration file support; by default ```mqtt-arp``` will read ```/etc/mqtt-arp.conf```. The location can be overridable, see below. 
+There is basic configuration file support; by default ```mqtt-arp``` will read ```/etc/mqtt-arp.conf```. The location can be overridden, see below. 
 The following aspects can be configured at run time:
 
  * MQTT host (-h / --host / mqtt_host)

--- a/mqtt-arp.c
+++ b/mqtt-arp.c
@@ -351,6 +351,7 @@ struct option long_options[] = {
 	{ "topic", required_argument, 0, 't' },
 	{ "username", required_argument, 0, 'u' },
 	{ "verbose", no_argument, 0, 'v' },
+	{ "configfile", required_argument, 0, 'f' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -362,12 +363,22 @@ int main(int argc, char *argv[])
 	int option_index = 0;
 	int macs = 0;
 	int c;
+	char *config_file = CONFIG_FILE;
 
 	bzero(&config, sizeof(config));
 	config.mqtt_port = MQTT_PORT;
 
-	/* Read config before parsing command line */
-	read_config(CONFIG_FILE, &config, &macs);
+	while (1) {
+		c = getopt_long(argc, argv, "f:", long_options, &option_index);
+		if (c == -1)
+			break;
+		if (c == 'f') {
+			config_file = optarg;
+			break;
+		}
+	}
+
+	read_config(config_file, &config, &macs);
 
 	while (1) {
 		c = getopt_long(argc, argv, "c:h:l:m:p:P:t:u:v",

--- a/mqtt-arp.c
+++ b/mqtt-arp.c
@@ -293,8 +293,10 @@ int read_config(char *file, struct ma_config *config, int *macs)
 	int i;
 
 	f = fopen(file, "r");
-	if (f == NULL)
+	if (f == NULL) {
+		printf("Could not read config file %s\n", file);
 		return errno;
+	}
 
 #define INT_OPTION(opt, var) \
 	if (strncmp(line, opt " ", sizeof(opt)) == 0) { \

--- a/mqtt-arp.c
+++ b/mqtt-arp.c
@@ -294,7 +294,7 @@ int read_config(char *file, struct ma_config *config, int *macs)
 
 	f = fopen(file, "r");
 	if (f == NULL) {
-		printf("Could not read config file %s\n", file);
+		fprintf(stderr, "Could not read config file %s\n", file);
 		return errno;
 	}
 
@@ -343,6 +343,61 @@ int read_config(char *file, struct ma_config *config, int *macs)
 	return 0;
 }
 
+void override_config(const struct ma_config *source, struct ma_config *target) {
+    if(source->mqtt_host != NULL) {
+        target->mqtt_host = source->mqtt_host;
+    }
+    if(source->mqtt_port != 0) {
+        target->mqtt_port = source->mqtt_port;
+    }
+    if(source->mqtt_username != NULL) {
+        target->mqtt_username = source->mqtt_username;
+    }
+    if(source->mqtt_password != NULL) {
+        target->mqtt_password = source->mqtt_password;
+    }
+    if(source->mqtt_topic != NULL) {
+        target->mqtt_topic = source->mqtt_topic;
+    }
+    if(source->location != NULL) {
+        target->location = source->location;
+    }
+    if(source->capath != NULL) {
+        target->capath = source->capath;
+    }
+    for(int i = 0; i < MAX_MACS; ++i) {
+        if(source->macs[i].valid) {
+            memcpy(&target->macs[i], &source->macs[i], sizeof(struct mac_entry));
+        }
+    }
+}
+
+void print_config(const struct ma_config *config) {
+    printf("Config:\n");
+    printf("mqtt_host: %s\n", config->mqtt_host ? config->mqtt_host : "NULL");
+    printf("mqtt_port: %d\n", config->mqtt_port);
+    printf("mqtt_username: %s\n", config->mqtt_username ? config->mqtt_username : "NULL");
+    printf("mqtt_password: %s\n", config->mqtt_password ? config->mqtt_password : "NULL");
+    printf("mqtt_topic: %s\n", config->mqtt_topic ? config->mqtt_topic : "NULL");
+    printf("location: %s\n", config->location ? config->location : "NULL");
+    printf("capath: %s\n", config->capath ? config->capath : "NULL");
+    for(int i = 0; i < MAX_MACS; ++i) {
+        if(config->macs[i].valid) {
+            printf("macs[%d]: { valid: true, mac: ", i);
+            for(int j = 0; j < 6; ++j) {
+                printf("%02x", config->macs[i].mac[j]);
+                if(j < 5) {
+                    printf(":");
+                }
+            }
+            printf("\n");
+        }
+        else {
+            printf("macs[%d]: { valid: false }\n", i);
+        }
+    }
+}
+
 struct option long_options[] = {
 	{ "capath", required_argument, 0, 'c' },
 	{ "host", required_argument, 0, 'h' },
@@ -362,28 +417,16 @@ int main(int argc, char *argv[])
 	int sock;
 	struct mosquitto *mosq;
 	struct ma_config config;
+	struct ma_config cmdline_config;
 	int option_index = 0;
 	int macs = 0;
 	int c;
 	char *config_file = CONFIG_FILE;
 
 	bzero(&config, sizeof(config));
+	bzero(&cmdline_config, sizeof(cmdline_config));
 	config.mqtt_port = MQTT_PORT;
 
-	opterr = 0;
-	while (1) {
-		c = getopt_long(argc, argv, "f:", long_options, &option_index);
-		if (c == -1)
-			break;
-		if (c == 'f') {
-			config_file = optarg;
-			break;
-		}
-	}
-	read_config(config_file, &config, &macs);
-
-	optind = 0;
-	option_index = 0;
 	while (1) {
 		c = getopt_long(argc, argv, "c:h:l:m:p:P:t:u:f:v",
 				long_options, &option_index);
@@ -392,15 +435,16 @@ int main(int argc, char *argv[])
 			break;
 		switch (c) {
 		case 'f':
-			continue;
+			config_file = optarg;
+			break;
 		case 'c':
-			config.capath = optarg;
+			cmdline_config.capath = optarg;
 			break;
 		case 'h':
-			config.mqtt_host = optarg;
+			cmdline_config.mqtt_host = optarg;
 			break;
 		case 'l':
-			config.location = optarg;
+			cmdline_config.location = optarg;
 			break;
 		case 'm':
 			if (macs >= MAX_MACS) {
@@ -410,26 +454,26 @@ int main(int argc, char *argv[])
 			}
 			sscanf(optarg,
 				"%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
-				&config.macs[macs].mac[0],
-				&config.macs[macs].mac[1],
-				&config.macs[macs].mac[2],
-				&config.macs[macs].mac[3],
-				&config.macs[macs].mac[4],
-				&config.macs[macs].mac[5]);
-			config.macs[macs].valid = true;
+				&cmdline_config.macs[macs].mac[0],
+				&cmdline_config.macs[macs].mac[1],
+				&cmdline_config.macs[macs].mac[2],
+				&cmdline_config.macs[macs].mac[3],
+				&cmdline_config.macs[macs].mac[4],
+				&cmdline_config.macs[macs].mac[5]);
+			cmdline_config.macs[macs].valid = true;
 			macs++;
 			break;
 		case 'p':
-			config.mqtt_port = atoi(optarg);
+			cmdline_config.mqtt_port = atoi(optarg);
 			break;
 		case 'P':
-			config.mqtt_password = optarg;
+			cmdline_config.mqtt_password = optarg;
 			break;
 		case 't':
-			config.mqtt_topic = optarg;
+			cmdline_config.mqtt_topic = optarg;
 			break;
 		case 'u':
-			config.mqtt_username = optarg;
+			cmdline_config.mqtt_username = optarg;
 			break;
 		case 'v':
 			debug = true;
@@ -440,12 +484,19 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	read_config(config_file, &config, &macs);
+
+	override_config(&cmdline_config, &config);
+
 	if (!config.mqtt_host)
 		config.mqtt_host = MQTT_HOST;
 	if (!config.mqtt_topic)
 		config.mqtt_topic = MQTT_TOPIC;
 	if (!config.location)
 		config.location = LOCATION;
+
+	if (debug)
+		print_config(&config);
 
 	signal(SIGTERM, shutdown_request);
 

--- a/mqtt-arp.c
+++ b/mqtt-arp.c
@@ -370,6 +370,7 @@ int main(int argc, char *argv[])
 	bzero(&config, sizeof(config));
 	config.mqtt_port = MQTT_PORT;
 
+	opterr = 0;
 	while (1) {
 		c = getopt_long(argc, argv, "f:", long_options, &option_index);
 		if (c == -1)
@@ -379,17 +380,19 @@ int main(int argc, char *argv[])
 			break;
 		}
 	}
-
 	read_config(config_file, &config, &macs);
 
+	optind = 0;
+	option_index = 0;
 	while (1) {
-		c = getopt_long(argc, argv, "c:h:l:m:p:P:t:u:v",
+		c = getopt_long(argc, argv, "c:h:l:m:p:P:t:u:f:v",
 				long_options, &option_index);
 
 		if (c == -1)
 			break;
-
 		switch (c) {
+		case 'f':
+			continue;
 		case 'c':
 			config.capath = optarg;
 			break;


### PR DESCRIPTION
This PR makes it possible to specify a config file at another location than /etc/mqtt-arp.conf
A new command line argument -f / --configfile overrides the default location